### PR TITLE
Upgrade aws-actions/configure-aws-credentials from v4 to v6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Configure AWS Credential Profiles for GitHub Actions
 
-This action uses the official `aws-actions/configure-aws-credentials@v4` action. This action only supports assuming roles via OIDC.
+This action uses the official `aws-actions/configure-aws-credentials@v6` action. This action only supports assuming roles via OIDC.
 
 The official action is not sufficient for multiple account usage as it can only set one set of AWS environment variables at a time.
 

--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
   - name: Configure AWS Credentials
-    uses: aws-actions/configure-aws-credentials@v4
+    uses: aws-actions/configure-aws-credentials@v6
     with:
       role-to-assume: ${{ inputs.role-arn }}
       aws-region: ${{ inputs.region }}

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
     with:
       role-to-assume: ${{ inputs.role-arn }}
       aws-region: ${{ inputs.region }}
-      mask-aws-account-id: 'no'
+      mask-aws-account-id: 'false'
 
   - name: Setup Profile
     shell: bash


### PR DESCRIPTION
**Summary**
- Upgrade aws-actions/configure-aws-credentials from v4 to v6
- Fix mask-aws-account-id input to use YAML 1.2 Core Schema boolean ('false' instead of 'no'), as required by v6

**Why**
GitHub Actions runners are deprecating Node.js 20. `aws-actions/configure-aws-credentials@v4` runs on Node.js 20 and triggers a deprecation warning:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 18th, 2026.

Upgrading to v6 moves to a supported Node.js runtime and resolves this warning. v6 also enforces YAML 1.2 Core Schema for boolean inputs, requiring 'false' instead of 'no' for mask-aws-account-id.